### PR TITLE
Tweak user tracking in poll

### DIFF
--- a/pollBot.py
+++ b/pollBot.py
@@ -146,7 +146,7 @@ class PollBot(BotPlugin):
         if not option in options:
             return 'Option not found. Use !poll show to see all options of the current poll.'
 
-        username = mess.frm.stripped
+        username = mess.frm.client
 
         if username in usernames:
             return 'You have already voted.'


### PR DESCRIPTION
Change voting user tracking to use `client` property, `stripped` wasn't there for slack backend and it was exploding.
